### PR TITLE
feat: extend backward compatibility to JVM 11 and Gradle 6.0 #153

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -378,25 +378,26 @@ jobs:
 ###############################################################################################################################
   
   java-unit-test:
-    name: Test (Unit) - Java ${{ matrix.Java }}
+    name: Test (Unit) - Java # TODO: uncomment the following: ${{ matrix.java }}
     needs: build-java
     # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
     # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
     # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
-    strategy:
-      matrix:
-        java: [ '11', '16' ]
+    # TODO: uncomment the following lines
+    #strategy:
+    #  matrix:
+    #    java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK ${{ matrix.Java }}
+    - name: Set up JDK 16 # TODO: replace with the following: - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: ${{ matrix.Java }}
+        java-version: 16 # TODO: replace with the following: java-version: ${{ matrix.java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -450,13 +451,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json
+        name: .nyx-state-${{ github.job }}.json # TODO: replace with the following: name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-unit-test-reports
+        name: java-unit-test-reports # TODO: replace with the following: name: java-${{ matrix.java }}-unit-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco
@@ -467,25 +468,26 @@ jobs:
   # limit defined by GitHub Actions. This is why they are in a separate job and the output cache
   # may fail to store at the end (but this won't affect other jobs).
   java-integration-test:
-    name: Test (Integration) - Java ${{ matrix.Java }}
+    name: Test (Integration) - Java # TODO: uncomment the following: ${{ matrix.java }}
     needs: java-unit-test
     # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
     # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
     # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
-    strategy:
-      matrix:
-        java: [ '11', '16' ]
+    # TODO: uncomment the following lines
+    #strategy:
+    #  matrix:
+    #    java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK ${{ matrix.Java }}
+    - name: Set up JDK 16 # TODO: replace with the following: - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: ${{ matrix.Java }}
+        java-version: 16 # TODO: replace with the following: java-version: ${{ matrix.java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -551,13 +553,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json
+        name: .nyx-state-${{ github.job }}.json # TODO: replace with the following: name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-integration-test-reports
+        name: java-integration-test-reports # TODO: replace with the following: name: java-${{ matrix.java }}-integration-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco
@@ -568,25 +570,26 @@ jobs:
   # limit defined by GitHub Actions. This is why they are in a separate job and the output cache
   # may fail to store at the end (but this won't affect other jobs).
   java-functional-test:
-    name: Test (Functional) - Java ${{ matrix.Java }}
+    name: Test (Functional) - Java # TODO: uncomment the following: ${{ matrix.java }}
     needs: java-integration-test
     # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
     # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
     # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
-    strategy:
-      matrix:
-        java: [ '11', '16' ]
+    # TODO: uncomment the following lines
+    #strategy:
+    #  matrix:
+    #    java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK ${{ matrix.Java }}
+    - name: Set up JDK 16 # TODO: replace with the following: - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: ${{ matrix.Java }}
+        java-version: 16 # TODO: replace with the following: java-version: ${{ matrix.java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -653,13 +656,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json
+        name: .nyx-state-${{ github.job }}.json # TODO: replace with the following: name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-functional-test-reports
+        name: java-functional-test-reports # TODO: replace with the following: name: java-${{ matrix.java }}-functional-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco
@@ -743,13 +746,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json
+        name: .nyx-state-${{ github.job }}-${{ matrix.os }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: go-unit-test-reports
+        name: go-${{ matrix.os }}-unit-test-reports
         path: |
           modules/go/**/build/reports/tests/test/
           modules/go/**/build/test-results/test/
@@ -846,13 +849,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json
+        name: .nyx-state-${{ github.job }}-${{ matrix.os }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: go-integration-test-reports
+        name: go-${{ matrix.os }}-integration-test-reports
         path: |
           modules/go/**/build/reports/tests/integrationTest/
           modules/go/**/build/test-results/integrationTest/
@@ -950,13 +953,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json
+        name: .nyx-state-${{ github.job }}-${{ matrix.os }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: go-functional-test-reports
+        name: go-${{ matrix.os }}-functional-test-reports
         path: |
           modules/go/**/build/reports/tests/functionalTest/
           modules/go/**/build/test-results/functionalTest/

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -378,19 +378,25 @@ jobs:
 ###############################################################################################################################
   
   java-unit-test:
-    name: Test (Unit) - Java
+    name: Test (Unit) - Java ${{ matrix.Java }}
     needs: build-java
+    # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
+    # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
+    # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
+    strategy:
+      matrix:
+        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK 16
+    - name: Set up JDK ${{ matrix.Java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 16
+        java-version: ${{ matrix.Java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -461,19 +467,25 @@ jobs:
   # limit defined by GitHub Actions. This is why they are in a separate job and the output cache
   # may fail to store at the end (but this won't affect other jobs).
   java-integration-test:
-    name: Test (Integration) - Java
+    name: Test (Integration) - Java ${{ matrix.Java }}
     needs: java-unit-test
+    # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
+    # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
+    # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
+    strategy:
+      matrix:
+        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK 16
+    - name: Set up JDK ${{ matrix.Java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 16
+        java-version: ${{ matrix.Java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -556,19 +568,25 @@ jobs:
   # limit defined by GitHub Actions. This is why they are in a separate job and the output cache
   # may fail to store at the end (but this won't affect other jobs).
   java-functional-test:
-    name: Test (Functional) - Java
+    name: Test (Functional) - Java ${{ matrix.Java }}
     needs: java-integration-test
+    # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
+    # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
+    # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
+    strategy:
+      matrix:
+        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK 16
+    - name: Set up JDK ${{ matrix.Java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 16
+        java-version: ${{ matrix.Java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -378,25 +378,19 @@ jobs:
 ###############################################################################################################################
   
   java-unit-test:
-    name: Test (Unit) - Java ${{ matrix.java }}
+    name: Test (Unit) - Java
     needs: build-java
-    # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
-    # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
-    # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
-    strategy:
-      matrix:
-        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK 16
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: ${{ matrix.java }}
+        java-version: 16
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -450,13 +444,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
+        name: .nyx-state-${{ github.job }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-${{ matrix.java }}-unit-test-reports
+        name: java-unit-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco
@@ -467,25 +461,19 @@ jobs:
   # limit defined by GitHub Actions. This is why they are in a separate job and the output cache
   # may fail to store at the end (but this won't affect other jobs).
   java-integration-test:
-    name: Test (Integration) - Java ${{ matrix.java }}
+    name: Test (Integration) - Java
     needs: java-unit-test
-    # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
-    # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
-    # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
-    strategy:
-      matrix:
-        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK 16
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: ${{ matrix.java }}
+        java-version: 16
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -551,13 +539,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
+        name: .nyx-state-${{ github.job }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-${{ matrix.java }}-integration-test-reports
+        name: java-integration-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco
@@ -568,25 +556,19 @@ jobs:
   # limit defined by GitHub Actions. This is why they are in a separate job and the output cache
   # may fail to store at the end (but this won't affect other jobs).
   java-functional-test:
-    name: Test (Functional) - Java ${{ matrix.java }}
+    name: Test (Functional) - Java
     needs: java-integration-test
-    # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
-    # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
-    # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
-    strategy:
-      matrix:
-        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK 16
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: ${{ matrix.java }}
+        java-version: 16
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -653,13 +635,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
+        name: .nyx-state-${{ github.job }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-${{ matrix.java }}-functional-test-reports
+        name: java-functional-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -378,19 +378,25 @@ jobs:
 ###############################################################################################################################
   
   java-unit-test:
-    name: Test (Unit) - Java
+    name: Test (Unit) - Java ${{ matrix.java }}
     needs: build-java
+    # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
+    # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
+    # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
+    strategy:
+      matrix:
+        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK 16
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 16
+        java-version: ${{ matrix.java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -444,13 +450,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json
+        name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-unit-test-reports
+        name: java-${{ matrix.java }}-unit-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco
@@ -461,19 +467,25 @@ jobs:
   # limit defined by GitHub Actions. This is why they are in a separate job and the output cache
   # may fail to store at the end (but this won't affect other jobs).
   java-integration-test:
-    name: Test (Integration) - Java
+    name: Test (Integration) - Java ${{ matrix.java }}
     needs: java-unit-test
+    # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
+    # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
+    # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
+    strategy:
+      matrix:
+        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK 16
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 16
+        java-version: ${{ matrix.java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -539,13 +551,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json
+        name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-integration-test-reports
+        name: java-${{ matrix.java }}-integration-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco
@@ -556,19 +568,25 @@ jobs:
   # limit defined by GitHub Actions. This is why they are in a separate job and the output cache
   # may fail to store at the end (but this won't affect other jobs).
   java-functional-test:
-    name: Test (Functional) - Java
+    name: Test (Functional) - Java ${{ matrix.java }}
     needs: java-integration-test
+    # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
+    # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
+    # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
+    strategy:
+      matrix:
+        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK 16
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 16
+        java-version: ${{ matrix.java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -635,13 +653,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json
+        name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-functional-test-reports
+        name: java-${{ matrix.java }}-functional-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -378,26 +378,25 @@ jobs:
 ###############################################################################################################################
   
   java-unit-test:
-    name: Test (Unit) - Java # TODO: uncomment the following: ${{ matrix.java }}
+    name: Test (Unit) - Java ${{ matrix.java }}
     needs: build-java
     # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
     # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
     # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
-    # TODO: uncomment the following lines
-    #strategy:
-    #  matrix:
-    #    java: [ '11', '16' ]
+    strategy:
+      matrix:
+        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK 16 # TODO: replace with the following: - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 16 # TODO: replace with the following: java-version: ${{ matrix.java }}
+        java-version: ${{ matrix.java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -451,13 +450,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json # TODO: replace with the following: name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
+        name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-unit-test-reports # TODO: replace with the following: name: java-${{ matrix.java }}-unit-test-reports
+        name: java-${{ matrix.java }}-unit-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco
@@ -468,26 +467,25 @@ jobs:
   # limit defined by GitHub Actions. This is why they are in a separate job and the output cache
   # may fail to store at the end (but this won't affect other jobs).
   java-integration-test:
-    name: Test (Integration) - Java # TODO: uncomment the following: ${{ matrix.java }}
+    name: Test (Integration) - Java ${{ matrix.java }}
     needs: java-unit-test
     # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
     # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
     # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
-    # TODO: uncomment the following lines
-    #strategy:
-    #  matrix:
-    #    java: [ '11', '16' ]
+    strategy:
+      matrix:
+        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK 16 # TODO: replace with the following: - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 16 # TODO: replace with the following: java-version: ${{ matrix.java }}
+        java-version: ${{ matrix.java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -553,13 +551,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json # TODO: replace with the following: name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
+        name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-integration-test-reports # TODO: replace with the following: name: java-${{ matrix.java }}-integration-test-reports
+        name: java-${{ matrix.java }}-integration-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco
@@ -570,26 +568,25 @@ jobs:
   # limit defined by GitHub Actions. This is why they are in a separate job and the output cache
   # may fail to store at the end (but this won't affect other jobs).
   java-functional-test:
-    name: Test (Functional) - Java # TODO: uncomment the following: ${{ matrix.java }}
+    name: Test (Functional) - Java ${{ matrix.java }}
     needs: java-integration-test
     # The recommended JDK version is 15 or above but since we need to test for backward compatibility to JVMs 11 or newer we
     # need a matrix here. Depending on the JDK version the set of Gradle version that the tests run on will change, according
     # to the Gradle compatibility matrix. See CONTRIBUTING.md in the root directory or the Gradle functional test suites for more.
-    # TODO: uncomment the following lines
-    #strategy:
-    #  matrix:
-    #    java: [ '11', '16' ]
+    strategy:
+      matrix:
+        java: [ '11', '16' ]
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK 16 # TODO: replace with the following: - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 16 # TODO: replace with the following: java-version: ${{ matrix.java }}
+        java-version: ${{ matrix.java }}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Make Git ignore execute permission changes in files (like gradlew)
@@ -656,13 +653,13 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: .nyx-state-${{ github.job }}.json # TODO: replace with the following: name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
+        name: .nyx-state-${{ github.job }}-${{ matrix.java }}.json
         path: build/.nyx-state.json
     - name: Archive Test Outputs
       uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
-        name: java-functional-test-reports # TODO: replace with the following: name: java-${{ matrix.java }}-functional-test-reports
+        name: java-${{ matrix.java }}-functional-test-reports
         path: |
           modules/java/**/build/jacoco/
           modules/java/**/build/reports/jacoco

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ where the main tasks are:
 
 The `publish` and `release` tasks can only be executed on the CI/CD platform.
 
-The suggested JDK version is `15` or newer. JDK version older than `11` is not supported.
+The required JDK version is `15` or newer.
 
 The JDK version affects the number of functional tests excuted for the Gradle plugin, according to the [Gradle compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html). This means that newer JDKs will run functional tests against a reduced set of Gradle versions because [TestKit](https://docs.gradle.org/current/userguide/test_kit.html) uses the original Java binaries for each tested Gradle release and Java classes compiled for JVM versions published after the Gradle release would raise an exception like `unsupported class file major version XY`. You don't need to worry about this (as it's already taken care of in the functional test suites) unless you need to run functional tests against a specific gradle version that is not covered by the tests due to the JDK version you're using.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ where the main tasks are:
 
 The `publish` and `release` tasks can only be executed on the CI/CD platform.
 
-The required JDK version is `15` or newer.
+The recommended JDK version is `15` or newer. JDK version older than `11` is not supported.
 
 The JDK version affects the number of functional tests excuted for the Gradle plugin, according to the [Gradle compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html). This means that newer JDKs will run functional tests against a reduced set of Gradle versions because [TestKit](https://docs.gradle.org/current/userguide/test_kit.html) uses the original Java binaries for each tested Gradle release and Java classes compiled for JVM versions published after the Gradle release would raise an exception like `unsupported class file major version XY`. You don't need to worry about this (as it's already taken care of in the functional test suites) unless you need to run functional tests against a specific gradle version that is not covered by the tests due to the JDK version you're using.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,9 @@ where the main tasks are:
 
 The `publish` and `release` tasks can only be executed on the CI/CD platform.
 
-Use the most recent [Gradle release](https://gradle.org/releases/), at least version `7.0`. The JDK must be at least version `15`, but consider that newer versions may cause errors like `unsupported class file major version XY` when running Gradle functional tests (due to [Gradle TestKit](https://docs.gradle.org/current/userguide/test_kit.html) when testing simulating older versions of Gradle).
+The suggested JDK version is `15` or newer. JDK version older than `11` is not supported.
+
+The JDK version affects the number of functional tests excuted for the Gradle plugin, according to the [Gradle compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html). This means that newer JDKs will run functional tests against a reduced set of Gradle versions because [TestKit](https://docs.gradle.org/current/userguide/test_kit.html) uses the original Java binaries for each tested Gradle release and Java classes compiled for JVM versions published after the Gradle release would raise an exception like `unsupported class file major version XY`. You don't need to worry about this (as it's already taken care of in the functional test suites) unless you need to run functional tests against a specific gradle version that is not covered by the tests due to the JDK version you're using.
 
 ### Contributing Documentation
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,12 @@ There are no actions to take for backward compatibility.
 
 ### New features and improvements
 
-There are no new features but a few improvements in the build process and an upgrade of all the plugins, tools and libraries used in the project.
+This release:
+
+* this release extends backward compatibility for the Java version (the command line version is not affected) ([#153](https://github.com/mooltiverse/nyx/issues/153)), in details:
+  * the recommended JVM version is `15` or newer and the recommended Gradle version is `7.0` or newer
+  * older Java versions starting from `11` and older Gradle versions starting from `6.0` are supported with the exception of Gradle versions between `6.5` and `6.9.3` (see [#153](https://github.com/mooltiverse/nyx/issues/153#issuecomment-1416732299))
+  * JVM versions older than `11` and Gradle versions older than `6.0` are not supported
 
 ### Fixed issues
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,12 +10,7 @@ There are no actions to take for backward compatibility.
 
 ### New features and improvements
 
-This release:
-
-* this release extends backward compatibility for the Java version (the command line version is not affected), in details:
-  * the recommended JVM version is `15` or newer and the recommended Gradle version is `7.0` or newer
-  * older Java versions are supported starting from `11` and older Gradle versions are supported starting from `6.0`)
-  * JVM versions older than `11` and Gradle versions older than `6.0` are not supported
+There are no new features but a few improvements in the build process and an upgrade of all the plugins, tools and libraries used in the project.
 
 ### Fixed issues
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,26 @@
 # Nyx Release Notes
 
+## 2.1.0
+
+This release is available at [this link](https://github.com/mooltiverse/nyx/releases/tag/2.1.0).
+
+### Upgrade instructions
+
+There are no actions to take for backward compatibility.
+
+### New features and improvements
+
+This release:
+
+* this release extends backward compatibility for the Java version (the command line version is not affected), in details:
+  * the recommended JVM version is `15` or newer and the recommended Gradle version is `7.0` or newer
+  * older Java versions are supported starting from `11` and older Gradle versions are supported starting from `6.0`)
+  * JVM versions older than `11` and Gradle versions older than `6.0` are not supported
+
+### Fixed issues
+
+There are no fixes in this release.
+
 ## 2.0.0
 
 * when using the Java (Gradle) version, the minimum Java version is now `15` and the minimum Gradle version is `7.0` (see [here](https://mooltiverse.github.io/nyx/guide/user/introduction/usage/#requisites-1) and [here](https://docs.gradle.org/current/userguide/compatibility.html)); Gradle versions from `6.7` on should still work but they are no longer tested

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -59,6 +59,8 @@ nav-user-guide:
     children:
       - title: "How Nyx Works"
         url: /guide/user/introduction/how-nyx-works/
+      - title: "Requirements"
+        url: /guide/user/introduction/requirements/
       - title: "Usage"
         url: /guide/user/introduction/usage/
       - title: "Combined Release Process"

--- a/docs/_pages/guide/user/02.introduction/requirments.md
+++ b/docs/_pages/guide/user/02.introduction/requirments.md
@@ -1,0 +1,55 @@
+---
+title: Requirements
+layout: single
+toc: true
+permalink: /guide/user/introduction/requirements/
+---
+
+## System requirements
+
+### Command line binaries
+
+Supported platforms are those listed in the [available release assets](https://github.com/mooltiverse/nyx/releases/latest), namely:
+
+* `darwin` `amd64`
+* `darwin` `arm64`
+* `dragonfly` `amd64`
+* `freebsd` `386`
+* `freebsd` `amd64`
+* `freebsd` `arm`
+* `linux` `386`
+* `linux` `amd64`
+* `linux` `arm`
+* `linux` `arm64`
+* `linux` `ppc64`
+* `linux` `ppc64le`
+* `linux` `mips`
+* `linux` `mipsle`
+* `linux` `mips64`
+* `linux` `mips64le`
+* `netbsd` `386`
+* `netbsd` `amd64`
+* `netbsd` `arm`
+* `openbsd` `386`
+* `openbsd` `amd64`
+* `openbsd` `arm`
+* `openbsd` `arm64`
+* `solaris` `amd64`
+* `windows` `386`
+* `windows` `amd64`
+* `windows` `arm`
+* `windows` `arm64`
+
+### Docker
+
+There are no known incompatibilities for the Docker image therefore it is compatible with any container engine.
+
+### Java and Gradle
+
+The recommended runtime is Java VM `15` or newer and Gradle `7.0` or newer.
+
+Although you may encounter some limitations (i.e. about support for some encryption or hashing algorithms when using SSH authentication), older versions are also supported. Specifically, Java VM `11` or newer are supported and Gradle version `6.0` and later is supported with the exception of versions from `6.5.x` to `6.9`.x (due to the [ASM](https://asm.ow2.io/index.html) version used by Gradle).
+
+Java VMs older than `11` and Gradle versions older than `6.0` are not supported.
+
+[Here](https://gradle.org/releases/) you can find the list of available releases and [here](https://docs.gradle.org/current/userguide/compatibility.html) is the Gradle compatibility matrix.

--- a/docs/_pages/guide/user/02.introduction/usage.md
+++ b/docs/_pages/guide/user/02.introduction/usage.md
@@ -228,13 +228,6 @@ All the examples in this page assume you're using the plain `gradle` command. If
 Some extra information on the Gradle Plugin internals is available [here]({{ site.baseurl }}{% link _pages/guide/user/07.in-depth/gradle-plugin.md %}).
 {: .notice--info}
 
-### Requisites
-
-In order to run the Gradle plugin you need:
-
-* Java release `15` or later
-* Gradle release `6.7` or later. Tests have been successfully executed up to release `7.6`. [Here](https://gradle.org/releases/) you can find the list of available releases and [here](https://docs.gradle.org/current/userguide/compatibility.html) is the Gradle compatibility matrix
-
 ### Apply the plugin
 
 You can apply the [plugin](https://plugins.gradle.org/plugin/com.mooltiverse.oss.nyx) as a *project plugin* or as a *settings plugin*. You're suggested to use the *settings plugin* to make sure you have properties are evaluated early in the build lifecycle as detailed in [this post]({{ site.baseurl }}{% link _posts/2020-01-01-the-gradle-version-project-property-is-unspecified.md %}).

--- a/docs/_pages/guide/user/02.introduction/usage.md
+++ b/docs/_pages/guide/user/02.introduction/usage.md
@@ -230,13 +230,10 @@ Some extra information on the Gradle Plugin internals is available [here]({{ sit
 
 ### Requisites
 
-The recommended runtime to run the Gradle plugin is Gradle `7.0` or newer and Java VM `15` or newer.
+In order to run the Gradle plugin you need:
 
-Although you may encounter some limitations (i.e. about support for some encryption or hashing algorithms when using SSH authentication), older versions are also supported. Specifically, Java VM `11` or newer are supported and Gradle version `6.0` is supported.
-
-Java VMs older than `11` and Gradle versions older than `6.0` are not supported.
-
-[Here](https://gradle.org/releases/) you can find the list of available releases and [here](https://docs.gradle.org/current/userguide/compatibility.html) is the Gradle compatibility matrix.
+* Java release `15` or later
+* Gradle release `6.7` or later. Tests have been successfully executed up to release `7.6`. [Here](https://gradle.org/releases/) you can find the list of available releases and [here](https://docs.gradle.org/current/userguide/compatibility.html) is the Gradle compatibility matrix
 
 ### Apply the plugin
 

--- a/docs/_pages/guide/user/02.introduction/usage.md
+++ b/docs/_pages/guide/user/02.introduction/usage.md
@@ -230,10 +230,13 @@ Some extra information on the Gradle Plugin internals is available [here]({{ sit
 
 ### Requisites
 
-In order to run the Gradle plugin you need:
+The recommended runtime to run the Gradle plugin is Gradle `7.0` or newer and Java VM `15` or newer.
 
-* Java release `15` or later
-* Gradle release `7.0` or later. Tests have been successfully executed up to release `7.6`. [Here](https://gradle.org/releases/) you can find the list of available releases and [here](https://docs.gradle.org/current/userguide/compatibility.html) is the Gradle compatibility matrix. Gradle versions from `6.7` should still work but are no longer tested
+Although you may encounter some limitations (i.e. about support for some encryption or hashing algorithms when using SSH authentication), older versions are also supported. Specifically, Java VM `11` or newer are supported and Gradle version `6.0` is supported.
+
+Java VMs older than `11` and Gradle versions older than `6.0` are not supported.
+
+[Here](https://gradle.org/releases/) you can find the list of available releases and [here](https://docs.gradle.org/current/userguide/compatibility.html) is the Gradle compatibility matrix.
 
 ### Apply the plugin
 

--- a/docs/_pages/guide/user/03.configuration-reference/git.md
+++ b/docs/_pages/guide/user/03.configuration-reference/git.md
@@ -21,7 +21,7 @@ Nyx uses external libraries to connect to remotes and so inherits their limitati
 
 The limitations coming from those libraries may show up, for example:
 
-* in case of unsupported key algorithms and formats (when using SSH keys)
+* in case of unsupported key algorithms and formats (when using SSH authentication to remote repositories)
 * in case of unsupported JVM versions (for the Java version)
 * when files are not found at their usual locations (i.e. `~/.ssh`, when using SSH keys)
 
@@ -52,7 +52,7 @@ Using public keys is encouraged for security reasons although it introduces some
 * when private keys are passed as parameters, remote key fingerprint check is not performed
 * ssh-agent (including Pageant) support is **experimental** to avoid entering the passphrase to private keys, when used
 
-Not all algorithms are supported on all platforms so make sure your keys are supported. A few handy references:
+Support for key algorithms depends on the platform and the remote service. A few handy references:
 
 * [Adding a new SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) shows instructions on how to set up SSH keys on GitHub along with supported key types
 * [Use SSH keys to communicate with GitLab](https://docs.gitlab.com/ee/user/ssh.html) shows instructions on how to set up SSH keys on GitLab along with supported key types

--- a/modules/java/build.gradle
+++ b/modules/java/build.gradle
@@ -147,8 +147,8 @@ allprojects {
     }
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_15
+        targetCompatibility = JavaVersion.VERSION_15
 
         withSourcesJar()
         withJavadocJar()

--- a/modules/java/build.gradle
+++ b/modules/java/build.gradle
@@ -147,8 +147,8 @@ allprojects {
     }
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_15
-        targetCompatibility = JavaVersion.VERSION_15
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
 
         withSourcesJar()
         withJavadocJar()

--- a/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/GradleCommand.java
+++ b/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/GradleCommand.java
@@ -15,8 +15,6 @@
  */
 package com.mooltiverse.oss.nyx.gradle;
 
-import java.io.File;
-
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 

--- a/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/Suites.java
+++ b/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/Suites.java
@@ -60,7 +60,7 @@ public class Suites {
         } catch (NumberFormatException nfe) {
             throw new java.lang.RuntimeException(String.format("Unable to inspect the current Java version. The system property '%s' value is '%s' and acnnot be parsed to a valid integer", "java.specification.version", javaVersionString), nfe);
         }
-        if (javaVersion < 15)
+        if (javaVersion < 11)
             throw new java.lang.RuntimeException(String.format("Java version '%d' is not supported by the Gradle versions supported by Nyx", javaVersion));
 
         // Now, with the runtime Java version we can determine the Gradle versions we can test, according to https://docs.gradle.org/current/userguide/compatibility.html
@@ -73,8 +73,8 @@ public class Suites {
         List<String> quickTestVersions = new ArrayList<String>();
         List<String> extensiveTestVersions = new ArrayList<String>();
 
-        // Java versions >= 15 are required
-        // Gradle versions from 7.0 on are recommended, while 6.7 is the minimum required
+        // Java versions >= 15 are recommended
+        // Gradle versions from 7.0 on are recommended
         if (javaVersion <= 19) {
             // the latest version is always among the 'quick' tests
             quickTestVersions.add("7.6");
@@ -130,7 +130,7 @@ public class Suites {
             extensiveTestVersions.add("6.4");
             extensiveTestVersions.add("6.3");
         }
-        /*if (javaVersion <= 13) {
+        if (javaVersion <= 13) {
             extensiveTestVersions.add("6.2.2");
             extensiveTestVersions.add("6.2.1");
             extensiveTestVersions.add("6.2");
@@ -138,7 +138,7 @@ public class Suites {
             extensiveTestVersions.add("6.1");
             extensiveTestVersions.add("6.0.1");
             extensiveTestVersions.add("6.0");
-        }*/
+        }
         /* Gradle versions prior than 6.0 fails to test with an exception like:
                 > Could not find method services() for arguments [build_4o3mdmvy94ykemibox706yopu$_run_closure1$_closure2@18c3fdb5] on object of type com.mooltiverse.oss.nyx.gradle.NyxExtension.
            This means it has a different method for setting nested blocks into the extension object.
@@ -257,7 +257,7 @@ public class Suites {
         System.out.println("    "+String.join(", ", extensiveTestVersions));System.out.flush();
         System.out.println("Running these tests with a lower JVM version extends the set of Gradle versions compatible for testing");System.out.flush();
         System.out.println("so if you're trying to test against a version not listed here you may just need to run on an older JVM,");System.out.flush();
-        System.out.println("as long as it's supported (15 or above).");System.out.flush();
+        System.out.println("as long as it's supported (11 or above).");System.out.flush();
         System.out.println("********************************************************************************************************");System.out.flush();
 
         // if quick tests are requested, just return the smallest significant versions, otherwise return the union between the two lists

--- a/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/Suites.java
+++ b/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/Suites.java
@@ -100,8 +100,11 @@ public class Suites {
             extensiveTestVersions.add("7.0.1");
             extensiveTestVersions.add("7.0");
         }
-        // Gradle versions between 6.7 and 7.0 (excluded) are not recommended but still supported
+        // Gradle versions between 6.0 and 7.0 (excluded) are not recommended but still supported for backward compatibility,
+        // with exceptions as per https://github.com/mooltiverse/nyx/issues/153
         if (javaVersion <= 15) {
+            // these versions are not supported due to the ASM version it uses, see https://github.com/mooltiverse/nyx/issues/153
+            /*
             extensiveTestVersions.add("6.9.3");
             extensiveTestVersions.add("6.9.2");
             extensiveTestVersions.add("6.9.1");
@@ -112,13 +115,17 @@ public class Suites {
             extensiveTestVersions.add("6.8");
             extensiveTestVersions.add("6.7.1");
             quickTestVersions.add("6.7"); // 6.7 is the minimum supported version so we keep it in the 'quick' tests
+            */
         }
-        // JVM prior than 15 are not supported so also Gradle versions not supporting JVMs from 15 on are not supported
-        /*if (javaVersion <= 14) {
+        // Java versions between 11 and 14 are not recommended but still supported for backward compatibility
+        if (javaVersion <= 14) {
+            // these versions are not supported due to the ASM version it uses, see https://github.com/mooltiverse/nyx/issues/153
+            /*
             extensiveTestVersions.add("6.6.1");
             extensiveTestVersions.add("6.6");
             extensiveTestVersions.add("6.5.1");
-            //extensiveTestVersions.add("6.5"); // - version "6.5" has a bug (https://github.com/gradle/gradle/issues/13367) that prevents us to test, fixed in "6.5.1"
+            //extensiveTestVersions.add("6.5"); // - this version has a bug (https://github.com/gradle/gradle/issues/13367) that prevents us to test, fixed in "6.5.1"
+            */
             extensiveTestVersions.add("6.4.1");
             extensiveTestVersions.add("6.4");
             extensiveTestVersions.add("6.3");

--- a/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/Suites.java
+++ b/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/Suites.java
@@ -60,7 +60,7 @@ public class Suites {
         } catch (NumberFormatException nfe) {
             throw new java.lang.RuntimeException(String.format("Unable to inspect the current Java version. The system property '%s' value is '%s' and acnnot be parsed to a valid integer", "java.specification.version", javaVersionString), nfe);
         }
-        if (javaVersion < 11)
+        if (javaVersion < 15)
             throw new java.lang.RuntimeException(String.format("Java version '%d' is not supported by the Gradle versions supported by Nyx", javaVersion));
 
         // Now, with the runtime Java version we can determine the Gradle versions we can test, according to https://docs.gradle.org/current/userguide/compatibility.html
@@ -73,8 +73,8 @@ public class Suites {
         List<String> quickTestVersions = new ArrayList<String>();
         List<String> extensiveTestVersions = new ArrayList<String>();
 
-        // Java versions >= 15 are recommended
-        // Gradle versions from 7.0 on are recommended
+        // Java versions >= 15 are required
+        // Gradle versions from 7.0 on are recommended, while 6.7 is the minimum required
         if (javaVersion <= 19) {
             // the latest version is always among the 'quick' tests
             quickTestVersions.add("7.6");
@@ -100,7 +100,7 @@ public class Suites {
             extensiveTestVersions.add("7.0.1");
             extensiveTestVersions.add("7.0");
         }
-        // Gradle versions between 6.0 and 7.0 (excluded) are not recommended but still supported for backward compatibility
+        // Gradle versions between 6.7 and 7.0 (excluded) are not recommended but still supported
         if (javaVersion <= 15) {
             extensiveTestVersions.add("6.9.3");
             extensiveTestVersions.add("6.9.2");
@@ -113,8 +113,8 @@ public class Suites {
             extensiveTestVersions.add("6.7.1");
             quickTestVersions.add("6.7"); // 6.7 is the minimum supported version so we keep it in the 'quick' tests
         }
-        // Java versions between 11 and 14 are not recommended but still supported for backward compatibility
-        if (javaVersion <= 14) {
+        // JVM prior than 15 are not supported so also Gradle versions not supporting JVMs from 15 on are not supported
+        /*if (javaVersion <= 14) {
             extensiveTestVersions.add("6.6.1");
             extensiveTestVersions.add("6.6");
             extensiveTestVersions.add("6.5.1");
@@ -122,8 +122,8 @@ public class Suites {
             extensiveTestVersions.add("6.4.1");
             extensiveTestVersions.add("6.4");
             extensiveTestVersions.add("6.3");
-        }
-        if (javaVersion <= 13) {
+        }*/
+        /*if (javaVersion <= 13) {
             extensiveTestVersions.add("6.2.2");
             extensiveTestVersions.add("6.2.1");
             extensiveTestVersions.add("6.2");
@@ -131,7 +131,7 @@ public class Suites {
             extensiveTestVersions.add("6.1");
             extensiveTestVersions.add("6.0.1");
             extensiveTestVersions.add("6.0");
-        }
+        }*/
         /* Gradle versions prior than 6.0 fails to test with an exception like:
                 > Could not find method services() for arguments [build_4o3mdmvy94ykemibox706yopu$_run_closure1$_closure2@18c3fdb5] on object of type com.mooltiverse.oss.nyx.gradle.NyxExtension.
            This means it has a different method for setting nested blocks into the extension object.
@@ -250,7 +250,7 @@ public class Suites {
         System.out.println("    "+String.join(", ", extensiveTestVersions));System.out.flush();
         System.out.println("Running these tests with a lower JVM version extends the set of Gradle versions compatible for testing");System.out.flush();
         System.out.println("so if you're trying to test against a version not listed here you may just need to run on an older JVM,");System.out.flush();
-        System.out.println("as long as it's supported (11 or above).");System.out.flush();
+        System.out.println("as long as it's supported (15 or above).");System.out.flush();
         System.out.println("********************************************************************************************************");System.out.flush();
 
         // if quick tests are requested, just return the smallest significant versions, otherwise return the union between the two lists

--- a/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/Suites.java
+++ b/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/Suites.java
@@ -129,7 +129,7 @@ public class Suites {
             extensiveTestVersions.add("6.4.1");
             extensiveTestVersions.add("6.4");
             extensiveTestVersions.add("6.3");
-        }*/
+        }
         /*if (javaVersion <= 13) {
             extensiveTestVersions.add("6.2.2");
             extensiveTestVersions.add("6.2.1");

--- a/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/TestSuite.java
+++ b/modules/java/gradle/src/functionalTest/java/com/mooltiverse/oss/nyx/gradle/TestSuite.java
@@ -150,7 +150,7 @@ public class TestSuite {
 	 * Returns a string description of the test suite.
 	 */
 	public String toString() {
-		return "Gradle"+(Objects.isNull(gradleVersion) ? " " : " "+gradleVersion+" ")+"Plugin"+(Objects.isNull(name) ? " (anonymous) " : " ("+name+") ");
+		return "Gradle "+(Objects.isNull(gradleVersion) ? "" : gradleVersion)+" Plugin "+(Objects.isNull(name) ? "(anonymous)" : "("+name+")"+" (JVM "+System.getProperty("java.specification.version")+")");
 	}
 
 	/**

--- a/modules/java/main/build.gradle
+++ b/modules/java/main/build.gradle
@@ -39,6 +39,9 @@ dependencies {
   implementation        'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4'          // Jackson YAML library (https://github.com/FasterXML/jackson-dataformats-text/tree/master/yaml)
   implementation        'com.github.jknack:handlebars:4.3.1'                                       // Handlebars library (https://github.com/jknack/handlebars.java)
   implementation        'org.kohsuke:github-api:1.313'                                             // GitHub API client Java library (https://github-api.kohsuke.org/)
+  // Bouncycastle is used by JSch to provide support for certain key types when running on older JVMs (see: https://github.com/mwiede/jsch#faq).
+  // JVMs from 15 on don't need Bouncycastle.
+  runtimeOnly           'org.bouncycastle:bcprov-jdk18on:1.72'                                     // Bouncycastle (https://www.bouncycastle.org/)
 
   // See the 'integrationTestExport' and 'functionalTestExport' above about this
   integrationTestExport  sourceSets.integrationTest.output

--- a/modules/java/main/build.gradle
+++ b/modules/java/main/build.gradle
@@ -39,9 +39,6 @@ dependencies {
   implementation        'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4'          // Jackson YAML library (https://github.com/FasterXML/jackson-dataformats-text/tree/master/yaml)
   implementation        'com.github.jknack:handlebars:4.3.1'                                       // Handlebars library (https://github.com/jknack/handlebars.java)
   implementation        'org.kohsuke:github-api:1.313'                                             // GitHub API client Java library (https://github-api.kohsuke.org/)
-  // Bouncycastle is used by JSch to provide support for certain key types when running on older JVMs (see: https://github.com/mwiede/jsch#faq).
-  // JVMs from 15 on don't need Bouncycastle.
-  runtimeOnly           'org.bouncycastle:bcprov-jdk18on:1.72'                                     // Bouncycastle (https://www.bouncycastle.org/)
 
   // See the 'integrationTestExport' and 'functionalTestExport' above about this
   integrationTestExport  sourceSets.integrationTest.output

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@
 ------------------------------------------------------------------------------*/
 plugins {
   // use our own plugin
-  id "com.mooltiverse.oss.nyx" version "2.0.0"
+  id "com.mooltiverse.oss.nyx" version "2.1.0-alpha.1"
 
   // Gradle Enterprise plugin (used for build scans)
   id "com.gradle.enterprise" version "3.12.3"

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@
 ------------------------------------------------------------------------------*/
 plugins {
   // use our own plugin
-  id "com.mooltiverse.oss.nyx" version "2.1.0-alpha.1"
+  id "com.mooltiverse.oss.nyx" version "2.0.0"
 
   // Gradle Enterprise plugin (used for build scans)
   id "com.gradle.enterprise" version "3.12.3"


### PR DESCRIPTION
an attempt was made to extend backward compatibility to JVM 11 and Gradle 6.0 (#153) with no luck, because the [JSch](https://github.com/mwiede/jsch) library does not support JVM 11 (so the classloader thrown an error `Unsupported class file major version 60`).